### PR TITLE
When copying to clipboard fails, persist anyway

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -62,10 +62,9 @@ pub fn callback_exec(matches: &getopts::Matches, store: &mut password::v2::Passw
 
                     if copy_to_clipboard(password_as_string_clipboard.deref()).is_err() {
                         println_ok!("Alright! Here is your password: {}", password_as_string_clipboard.deref());
-                        return Err(1);
+                    } else {
+                        println_ok!("Alright! I've saved your new password. You can paste it anywhere with {}.", paste_keys());
                     }
-
-                    println_ok!("Alright! I've saved your new password. You can paste it anywhere with {}.", paste_keys());
                 },
                 Err(err) => {
                     println_err!("Woops, I couldn't add the password ({:?}).", err);

--- a/src/commands/change.rs
+++ b/src/commands/change.rs
@@ -63,10 +63,10 @@ pub fn callback_exec(matches: &getopts::Matches, store: &mut password::v2::Passw
 
                     if copy_to_clipboard(password_as_string.deref()).is_err() {
                         println_ok!("Alright! Here is your new password: {}", password_as_string.deref());
-                        return Err(1);
+                    } else {
+                        println_ok!("Done! I've saved your new password for \"{}\". You can paste it anywhere with {}.", app_name, paste_keys());
                     }
 
-                    println_ok!("Done! I've saved your new password for \"{}\". You can paste it anywhere with {}.", app_name, paste_keys());
                     Ok(())
                 }
                 Err(err) => {

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -76,10 +76,10 @@ pub fn callback_exec(matches: &getopts::Matches, store: &mut password::v2::Passw
 
             if copy_to_clipboard(password_as_string_clipboard.deref()).is_err() {
                 println_ok!("Alright! Here is your password: {}", password_as_string_clipboard.deref());
-                return Err(1);
+            } else {
+                println_ok!("Alright! I've saved your new password. You can paste it anywhere with {}.", paste_keys());
             }
 
-            println_ok!("Alright! I've saved your new password. You can paste it anywhere with {}.", paste_keys());
             Ok(())
         },
         Err(err) => {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -46,9 +46,9 @@ pub fn callback_exec(matches: &getopts::Matches, store: &mut password::v2::Passw
 
             if copy_to_clipboard(password.password.deref()).is_err() {
                 println_err!("Alright! Here is your password: {}", password.password.deref());
-                return Err(1);
+            } else {
+                println_ok!("Alright! You can paste your password anywhere with {}.", paste_keys());
             }
-            println_ok!("Alright! You can paste your password anywhere with {}.", paste_keys());
             Ok(())
         },
         None => {

--- a/src/commands/regenerate.rs
+++ b/src/commands/regenerate.rs
@@ -73,10 +73,10 @@ pub fn callback_exec(matches: &getopts::Matches, store: &mut password::v2::Passw
 
             if copy_to_clipboard(password_as_string.deref()).is_err() {
                 println_ok!("Alright! Here is your new password: {}", password_as_string.deref());
-                return Err(1);
+            } else {
+                println_ok!("Done! I've saved your new password for \"{}\". You can paste it anywhere with {}.", app_name, paste_keys());
             }
 
-            println_ok!("Done! I've saved your new password for \"{}\". You can paste it anywhere with {}.", app_name, paste_keys());
             Ok(())
         }
         Err(err) => {


### PR DESCRIPTION
Via issue #8

The previous behavior is that when copying to the clipboard fails during
a rooster commands, the password would be printed but not persisted.
With this change, it will be printed and persisted.

Other possible approaches:

* don't print the password, tell the user the operation failed
* don't print the password, tell the user how they can see it if they
  want to (`rooster get site --show`)

I included `rooster get` in these changes for consistency. I wasn't
concerned about a change not being persisted, but I didn't *think* it
should exit 1 if all of the other instances of clipboard error handling
treat it as an acceptable circumstance.

The one thing I'm wondering is whether rooster should notify the user
that something went wrong during the copying so they can attempt to fix
it. What do you think, Conrad?