### PR TITLE
Add wayland clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 cargo install --root /usr rooster
 ```
 
+On **Wayland**:
+
+install [wl-clipboard](https://github.com/bugaevc/wl-clipboard)
+
+Make sure you have the following environment variable set: `XDG_SESSION_TYPE=wayland`
+
+
 For other distributions, the various Docker files can help you find which dependencies you need.
 
 Once you have installed Rooster (see instructions below), you can view documentation with:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Here's a list of existing Rooster contributors:
 - [@dwrensha](https://github.com/dwrensha)
 - [@Eternity-Yarr](https://github.com/Eternity-Yarr)
 - [@jaezun](https://github.com/jaezun)
+- [@kamiyaa](https://github.com/kamiyaa)
 - [@maxjacobson](https://github.com/maxjacobson)
 - [@qmx](https://github.com/qmx)
 - [@yamnikov-oleg](https://github.com/yamnikov-oleg)

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -118,13 +118,13 @@ pub fn copy_to_clipboard(s: &SafeString) -> Result<(), ()> {
 }
 
 #[cfg(target_os = "macos")]
-pub fn paste_keys() -> String {
-    "Cmd+V".to_string()
+pub fn paste_keys() -> &'static str {
+    "Cmd+V"
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn paste_keys() -> String {
-    "Ctrl+V".to_string()
+pub fn paste_keys() -> &'static str {
+    "Ctrl+V"
 }
 
 pub fn confirm_password_retrieved<

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -36,33 +36,17 @@ pub fn copy_to_clipboard(s: &SafeString) -> Result<(), ()> {
     use quale::which;
     use shell_escape;
     use std::process::Command;
+    use std::env;
 
     let password = SafeString::new(shell_escape::escape(s.deref().into()).into());
 
-    match which("xsel") {
-        Some(xsel) => {
-            let shell = format!(
-                "printf '%s' {} | {} -ib 2> /dev/null",
-                password.deref(),
-                xsel.to_string_lossy()
-            );
-            if Command::new("sh")
-                .args(&["-c", shell.as_str()])
-                .status()
-                .map_err(|_| ())?
-                .success()
-            {
-                Ok(())
-            } else {
-                Err(())
-            }
-        }
-        None => match which("xclip") {
-            Some(xclip) => {
+    fn wayland_clipboards(password: &SafeString) -> Result<(), ()> {
+        match which("wl-copy") {
+            Some(wl_copy) => {
                 let shell = format!(
-                    "printf '%s' {} | {} -selection clipboard 2> /dev/null",
+                    "printf '%s' {} | {} 2> /dev/null",
                     password.deref(),
-                    xclip.to_string_lossy()
+                    wl_copy.to_string_lossy()
                 );
                 if Command::new("sh")
                     .args(&["-c", shell.as_str()])
@@ -76,7 +60,60 @@ pub fn copy_to_clipboard(s: &SafeString) -> Result<(), ()> {
                 }
             }
             None => Err(()),
-        },
+        }
+    }
+
+    fn x11_clipboards(password: &SafeString) -> Result<(), ()> {
+        match which("xsel") {
+            Some(xsel) => {
+                let shell = format!(
+                    "printf '%s' {} | {} -ib 2> /dev/null",
+                    password.deref(),
+                    xsel.to_string_lossy()
+                );
+                if Command::new("sh")
+                    .args(&["-c", shell.as_str()])
+                    .status()
+                    .map_err(|_| ())?
+                    .success()
+                {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            None => match which("xclip") {
+                Some(xclip) => {
+                    let shell = format!(
+                        "printf '%s' {} | {} -selection clipboard 2> /dev/null",
+                        password.deref(),
+                        xclip.to_string_lossy()
+                    );
+                    if Command::new("sh")
+                        .args(&["-c", shell.as_str()])
+                        .status()
+                        .map_err(|_| ())?
+                        .success()
+                    {
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
+                }
+                None => Err(()),
+            }
+        }
+    }
+
+    match env::var_os("XDG_SESSION_TYPE") {
+        Some(s) if s == "wayland" => {
+            let s = wayland_clipboards(&password);
+            match s {
+                Ok(_) => Ok(()),
+                Err(_) => x11_clipboards(&password)
+            }
+        }
+        _ => x11_clipboards(&password),
     }
 }
 
@@ -136,3 +173,4 @@ pub fn confirm_password_retrieved<
         }
     }
 }
+


### PR DESCRIPTION
- change `paste_keys()` to return a `&'static str` instead of a `String`

Not sure how reliable `cli_clipboard` is but it seems to be working as intended.
The problem might be that rooster will require wayland protocols to be installed in order to compile now (on Linux)

Open to feedback